### PR TITLE
Specify UserAgent for mobile devices

### DIFF
--- a/phones/phones.html
+++ b/phones/phones.html
@@ -36,25 +36,25 @@
         <div id="device11Pro">
             <p id="iPhone11ProText">iPhone 11 Pro (375x812)</p>
             <img id="iPhone11ProImg" src="../assets/apple/NotchiPhoneBrowserDark.png">
-            <webview id="iPhone11Pro" src="" class="device" class="apple" class="phone">
+            <webview id="iPhone11Pro" src="" class="device" class="apple" class="phone" useragent="Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X)">
             </webview>
         </div>
         <div id="device11ProMax">
             <p id="iPhone11ProMaxText">iPhone 11 Pro Max (414x896)</p>
             <img id="iPhone11ProMaxImg" src="../assets/apple/NotchiPhoneBrowserDark.png">
-            <webview id="iPhone11ProMax" src="" class="device" class="apple" class="phone">
+            <webview id="iPhone11ProMax" src="" class="device" class="apple" class="phone" useragent="Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X)">
             </webview>
         </div>
         <div id="deviceA51">
             <p id="A51Text">Samsung Galaxy A51 (393x851)</p>
             <img id="samsungGalaxyA51Img" src="../assets/android/SamsungGalaxyA51Browser.png">
-            <webview id="samsungGalaxyA51" src="" class="device" class="android" class="phone">
+            <webview id="samsungGalaxyA51" src="" class="device" class="android" class="phone" useragent="Mozilla/5.0 (Linux; Android 9.0; SM-A51'20' Build/LMY47I; wv)">
             </webview>
         </div>
         <div id="devicePixel5">
             <p id="pixel5Text">Google Pixel 5 (375x812)</p>
             <img id="pixel5Img" src="../assets/android/Pixel5Browser.png">
-            <webview id="pixel5" src="" class="device" class="android" class="phone">
+            <webview id="pixel5" src="" class="device" class="android" class="phone" useragent="Mozilla/5.0 (Linux; Android 11; Pixel 5)">
             </webview>
         </div>
     </div>


### PR DESCRIPTION
## Motivation

I'v tried this awesome tool to test my web service.

But my web service changes the layout based on UserAgent.

This tool simulates an actual device such as an iPhone, but the UserAgent used is that of the host machine (eg. MacBook).

As a result, the layout could not be tested as expected.

## Details of Changes

I'v specified the `useragent` for each of the following webviews

- iPhone11Pro
- iPhone11ProMax
- samsungGalaxyA51
- pixel5

If this change is against the policy of the tool, please close it.

## Examples

before
<img width="284" alt="スクリーンショット 2021-10-06 23 02 47" src="https://user-images.githubusercontent.com/16274215/136218353-416b45a1-2a94-401e-8532-ec94ea2f72e3.png">


afte
<img width="279" alt="スクリーンショット 2021-10-06 23 02 58" src="https://user-images.githubusercontent.com/16274215/136218359-78a630a8-272f-43be-89b5-f6acdad8d2d8.png">
